### PR TITLE
Dedup database rake

### DIFF
--- a/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
+++ b/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
@@ -1,25 +1,4 @@
 namespace :db do
-  desc 'Drops all the collections for the database for the current Rails.env'
-  task :drop => :environment do
-    Mongoid.master.collections.each {|col| col.drop_indexes && col.drop unless ['system.indexes', 'system.users'].include?(col.name) }
-  end
-
-  desc 'Load the seed data from db/seeds.rb'
-  task :seed => :environment do
-    seed_file = File.join(Rails.application.root, 'db', 'seeds.rb')
-    load(seed_file) if File.exist?(seed_file)
-  end
-
-  desc 'Create the database, and initialize with the seed data'
-  task :setup => [ 'db:create', 'db:seed' ]
-
-  desc 'Delete data and seed'
-  task :reseed => [ 'db:drop', 'db:seed' ]
-
-  task :create => :environment do
-    # noop
-  end
-  
   desc 'Current database version'
   task :version => :environment do
     puts Mongoid::Migrator.current_version.to_s
@@ -66,17 +45,5 @@ namespace :db do
   task :rollback => :environment do
     step = ENV['STEP'] ? ENV['STEP'].to_i : 1
     Mongoid::Migrator.rollback('db/migrate/', step)
-  end
-
-  namespace :schema do
-    task :load do
-      # noop
-    end
-  end
-
-  namespace :test do
-    task :prepare do
-      # Stub out for MongoDB
-    end
   end
 end


### PR DESCRIPTION
Removed duplicate rake tasks, some of these like db:seed and db:drop caused the task to run twice, first Mongoid's version then Mongoid Rails Migrations' version.
