### PR TITLE
don't run seeds twice

### DIFF
--- a/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
+++ b/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
@@ -4,10 +4,13 @@ namespace :db do
     Mongoid.master.collections.each {|col| col.drop_indexes && col.drop unless ['system.indexes', 'system.users'].include?(col.name) }
   end
 
-  desc 'Load the seed data from db/seeds.rb'
-  task :seed => :environment do
-    seed_file = File.join(Rails.application.root, 'db', 'seeds.rb')
-    load(seed_file) if File.exist?(seed_file)
+  if not Rake::Task.task_defined?("db:seed")
+    # if another ORM has defined db:seed, don't run it twice.
+    desc 'Load the seed data from db/seeds.rb'
+    task :seed => :environment do
+      seed_file = File.join(Rails.application.root, 'db', 'seeds.rb')
+      load(seed_file) if File.exist?(seed_file)
+    end
   end
 
   desc 'Create the database, and initialize with the seed data'


### PR DESCRIPTION
defining db:seed can happen twice (once in mongoid, once here). wrap it in a conditional to make sure not to define it twice and running seeds twice.
