### PR TITLE
added a 'rollback_to' task to rollback to a particular version# along with all in-between

### DIFF
--- a/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
+++ b/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
@@ -195,6 +195,13 @@ module Mongoid #:nodoc
         move(:down, migrations_path, steps)
       end
 
+      def rollback_to(migrations_path, target_version)
+        all_versions = get_all_versions
+	rollback_to = all_versions.index(target_version.to_i) + 1
+	rollback_steps = all_versions.size - rollback_to
+	rollback migrations_path, rollback_steps
+      end
+
       def forward(migrations_path, steps=1)
         move(:up, migrations_path, steps)
       end

--- a/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
+++ b/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
@@ -79,6 +79,12 @@ namespace :db do
     Mongoid::Migrator.rollback('db/migrate/', step)
   end
 
+  desc 'Rolls the database back to the specified VERSION'
+  task :rollback_to => :environment do
+    version = ENV['VERSION'].to_i
+    Mongoid::Migrator.rollback_to('db/migrate/', version)
+  end
+
   namespace :schema do
     task :load do
       # noop

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -26,8 +26,8 @@ module Mongoid
     end
 
     def test_finds_migrations
-      assert Mongoid::Migrator.new(:up, MIGRATIONS_ROOT + "/valid").migrations.size == 2
-      assert_equal 2, Mongoid::Migrator.new(:up, MIGRATIONS_ROOT + "/valid").pending_migrations.size
+      assert Mongoid::Migrator.new(:up, MIGRATIONS_ROOT + "/valid").migrations.size == 3
+      assert_equal 3, Mongoid::Migrator.new(:up, MIGRATIONS_ROOT + "/valid").pending_migrations.size
     end
 
     def test_migrator_current_version
@@ -65,7 +65,7 @@ module Mongoid
       assert_equal 20100513063902, Mongoid::Migrator.current_version
 
       assert !SurveySchema.where(:label => 'Improvement Plan Survey').first.nil?
-      assert_equal 2, SurveySchema.all.size
+      assert_equal 3, SurveySchema.all.size
 
       Mongoid::Migrator.down(MIGRATIONS_ROOT + "/valid", 20100513054656)
       assert_equal 20100513054656, Mongoid::Migrator.current_version
@@ -79,9 +79,9 @@ module Mongoid
       Mongoid::Migrator.up(MIGRATIONS_ROOT + "/valid", 20100513054656)
       pending_migrations = Mongoid::Migrator.new(:up, MIGRATIONS_ROOT + "/valid").pending_migrations
 
-      assert_equal 1, pending_migrations.size
-      assert_equal pending_migrations[0].version, 20100513063902
-      assert_equal pending_migrations[0].name, 'AddImprovementPlanSurveySchema'
+      assert_equal 2, pending_migrations.size
+      assert_equal pending_migrations[1].version, 20100513063902
+      assert_equal pending_migrations[1].name, 'AddImprovementPlanSurveySchema'
     end
 
     def test_migrator_rollback
@@ -89,10 +89,21 @@ module Mongoid
       assert_equal(20100513063902, Mongoid::Migrator.current_version)
 
       Mongoid::Migrator.rollback(MIGRATIONS_ROOT + "/valid")
+      assert_equal(20100513055502, Mongoid::Migrator.current_version)
+
+      Mongoid::Migrator.rollback(MIGRATIONS_ROOT + "/valid")
       assert_equal(20100513054656, Mongoid::Migrator.current_version)
 
       Mongoid::Migrator.rollback(MIGRATIONS_ROOT + "/valid")
       assert_equal(0, Mongoid::Migrator.current_version)
+    end
+
+    def test_migrator_rollback_to
+      Mongoid::Migrator.migrate(MIGRATIONS_ROOT + "/valid")
+      assert_equal(20100513063902, Mongoid::Migrator.current_version)
+
+      Mongoid::Migrator.rollback_to(MIGRATIONS_ROOT + "/valid", 20100513054656)
+      assert_equal(20100513054656, Mongoid::Migrator.current_version)
     end
 
     def test_migrator_forward

--- a/test/migrations/valid/20100513055502_add_second_survey_schema.rb
+++ b/test/migrations/valid/20100513055502_add_second_survey_schema.rb
@@ -1,0 +1,10 @@
+class AddSecondSurveySchema < Mongoid::Migration
+  def self.up
+    SurveySchema.create(:label => 'First Survey')
+  end
+
+  def self.down
+    SurveySchema.where(:label => 'First Survey').first.destroy
+  end
+end
+


### PR DESCRIPTION
added a 'rollback_to' task to rollback to a particular version# along with all in-between, as 'down' just undo a particular version and 'rollback' takes steps

actually I was looking for it during a project but due to its non-availability, wrote a small wrapper around rollback..... thought might help others looking for similar functionality
