### PR TITLE
Mongoid is a real dependency not a development dependency

### DIFF
--- a/mongoid_rails_migrations.gemspec
+++ b/mongoid_rails_migrations.gemspec
@@ -24,9 +24,9 @@ Gem::Specification.new do |s|
   rails_version = '>= 3.2.0'
 
   s.add_dependency('bundler', '>= 1.0.0')
+  s.add_dependency('mongoid', '>= 3.0.0')
   s.add_dependency('rails',  rails_version)
   s.add_dependency('railties',  rails_version)
   s.add_dependency('activesupport',  rails_version)
-  s.add_development_dependency('mongoid', '>= 3.0.0')
   s.add_development_dependency('test-unit', '>= 2.5.0')
 end


### PR DESCRIPTION
I think it's better to have this dependency directly in gemspec. Because if we have a mongoid 2.x application bundler update mongoid_rails_migration because no incompatibility