### PR TITLE
Use correct logic for determining range of migrations to run

### DIFF
--- a/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
+++ b/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
@@ -287,7 +287,20 @@ module Mongoid #:nodoc
         raise UnknownMigrationVersionError.new(@target_version)
       end
 
-      start = up? ? 0 : (migrations.index(current) || 0)
+      if up?
+        if current
+          start = migrations.index(current) + 1
+        else
+          start = 0
+        end
+      else
+        if current
+          start = migrations.index(current)
+        else
+          start = 0
+        end
+      end
+
       finish = migrations.index(target) || migrations.size - 1
       runnable = migrations[start..finish]
 


### PR DESCRIPTION
The code for determining which migrations to run in an ActiveRecord
environment previously assumed that it should always start from the
first migration when migrating up.

Unless I'm very confused, it seems to me that in fact it should start
at the migration after the current one. This change implements that
functionality.
