### PR TITLE
Mongoid5 support

### DIFF
--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -21,7 +21,7 @@ module Mongoid
         Mongoid.default_client.database.drop
       else
         Mongoid.default_session.drop
-      end    
+      end
     end
 
     def teardown; end

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -17,7 +17,11 @@ module Mongoid
     def setup
       Mongoid::Migration.verbose = true
       # same as db:drop command in lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
-      Mongoid.default_session.drop
+      if Mongoid::VERSION =~ /^5\./
+        Mongoid.default_client.database.drop
+      else
+        Mongoid.default_session.drop
+      end    
     end
 
     def teardown; end


### PR DESCRIPTION
All tests now pass for mongoid 5 (which is in beta).

To test, add this line to the `Gemfile`:

```
gem 'mongoid', git: 'git@github.com:mongodb/mongoid.git'
```

BTW: I think it's rather odd that this change causes the gem to work even when not being tested.

PS: Not fully fully tested on live systems but all the tests in the test directory pass.