### PR TITLE
Multiple migration paths

### DIFF
--- a/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
+++ b/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
@@ -39,7 +39,7 @@ namespace :db do
   desc "Migrate the database through scripts in db/migrate. Target specific version with VERSION=x. Turn off output with VERBOSE=false."
   task :migrate => :environment do
     Mongoid::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
-    Mongoid::Migrator.migrate("db/migrate/", ENV["VERSION"] ? ENV["VERSION"].to_i : nil)
+    Mongoid::Migrator.migrate(Mongoid::Migrator.migrations_path, ENV["VERSION"] ? ENV["VERSION"].to_i : nil)
   end
 
   namespace :migrate do
@@ -62,21 +62,21 @@ namespace :db do
     task :up => :environment do
       version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
       raise "VERSION is required" unless version
-      Mongoid::Migrator.run(:up, "db/migrate/", version)
+      Mongoid::Migrator.run(:up, Mongoid::Migrator.migrations_path, version)
     end
 
     desc 'Runs the "down" for a given migration VERSION.'
     task :down => :environment do
       version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
       raise "VERSION is required" unless version
-      Mongoid::Migrator.run(:down, "db/migrate/", version)
+      Mongoid::Migrator.run(:down, Mongoid::Migrator.migrations_path, version)
     end
   end
 
   desc 'Rolls the database back to the previous migration. Specify the number of steps with STEP=n'
   task :rollback => :environment do
     step = ENV['STEP'] ? ENV['STEP'].to_i : 1
-    Mongoid::Migrator.rollback('db/migrate/', step)
+    Mongoid::Migrator.rollback(Mongoid::Migrator.migrations_path, step)
   end
 
   namespace :schema do

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -26,9 +26,24 @@ module Mongoid
       assert_equal 0, Mongoid::Migrator.current_version, "db:drop should take us down to version 0"
     end
 
+    def test_migrations_path
+      assert_equal ["db/migrate"], Mongoid::Migrator.migrations_path
+
+      Mongoid::Migrator.migrations_path += ["engines/my_engine/db/migrate"]
+
+      assert_equal ["db/migrate", "engines/my_engine/db/migrate"], Mongoid::Migrator.migrations_path
+    end
+
     def test_finds_migrations
       assert Mongoid::Migrator.new(:up, MIGRATIONS_ROOT + "/valid").migrations.size == 2
       assert_equal 2, Mongoid::Migrator.new(:up, MIGRATIONS_ROOT + "/valid").pending_migrations.size
+    end
+
+    def test_finds_migrations_in_multiple_paths
+      migration_paths = [MIGRATIONS_ROOT + "/valid", MIGRATIONS_ROOT + "/other_valid"]
+
+      assert Mongoid::Migrator.new(:up, migration_paths).migrations.size == 3
+      assert_equal 3, Mongoid::Migrator.new(:up, migration_paths).pending_migrations.size
     end
 
     def test_migrator_current_version

--- a/test/migrations/other_valid/20160509073459_add_other_plan_survey_schema.rb
+++ b/test/migrations/other_valid/20160509073459_add_other_plan_survey_schema.rb
@@ -1,0 +1,9 @@
+class AddOtherPlanSurveySchema < Mongoid::Migration
+  def self.up
+    SurveySchema.create(:label => 'Other Plan Survey')
+  end
+
+  def self.down
+    SurveySchema.where(:label => 'Other Plan Survey').first.destroy
+  end
+end


### PR DESCRIPTION
This pull-request allows `Mongoid::Migrator` to fetch migrations from multiple migration paths (instead of `db/migrate` by default).
I faced this problem when I was trying to keep my migrations inside Rails engine. This problem is solved easily for `ActiveRecord::Migration` because it allows app.config.paths['db/migrate']  to have more than one path (it is an instance of Rails::Paths::Path).
We are using single `db/migrate` path at the moment.
In this pull request I suggest making `Mongoid::Migrator` more configurable by adding an ability to set array of migration paths in class variable.
