### PR TITLE
Update migration.rb to no more use `alias_method_chain` which is deprecated with Rails 5.

### DIFF
--- a/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
+++ b/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
@@ -103,7 +103,8 @@ module Mongoid #:nodoc
 
           case sym
             when :up, :down
-              singleton_class.send(:alias_method_chain, sym, "benchmarks")
+              singleton_class.send(:alias_method, "#{sym}_without_benchmarks".to_sym, sym)
+              singleton_class.send(:alias_method, sym, "#{sym}_with_benchmarks".to_sym)
           end
         ensure
           @ignore_new_methods = false


### PR DESCRIPTION
Simply replace `alias_method_chain` with `alias_method`.