### PR TITLE
Add db:migrate:status rake task to check which migrations will be run.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ $ rails db:version
 
 # Compatibility
 
+* `1.2.x` targets Mongoid >= `4.0.0` and Rails >= `4.2.0`
 * `1.1.x` targets Mongoid >= `4.0.0` and Rails >= `4.2.0`
 * `1.0.0` targers Mongoid >= `3.0.0` and Rails >= `3.2.0`
 * `0.0.14` targets Mongoid >= `2.0.0` and Rails >= `3.0.0` (but < `3.2.0`)
@@ -35,7 +36,11 @@ $ rails db:version
 
 ## Unreleased
 [Compare master with 1.1.1](https://github.com/adacosta/mongoid_rails_migrations/compare/v1.1.1...master)
+
+## 1.2.0
+_23/10/2018_
 * Added a `rollback_to` task to rollback to a particular version (#17)
+* Added a `db:migrate:status` task to list pending migrations (#46)
 
 ## 1.1.1
 _18/08/2015_

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ $ rails db:rollback
 $ rails db:rollback_to VERSION=
 $ rails db:migrate:redo
 $ rails db:migrate:reset
+$ rails db:migrate:status
 $ rails db:reseed (handled by mongoid)
 $ rails db:version
 ```

--- a/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
+++ b/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
@@ -335,21 +335,11 @@ module Mongoid #:nodoc
     end
 
     def status
-      runnable = runnable_migrations
-
-      to_run = runnable.select do |migration|
-        if up?
-          !migrated.include?(migration.version.to_i)
-        elsif down?
-          migrated.include?(migration.version.to_i)
-        end
-      end
-
       database_name = Migration.connection.options[:database]
       puts "\ndatabase: #{database_name}\n\n"
       puts "#{'Status'.center(8)}  #{'Migration ID'.ljust(14)}  Migration Name"
       puts "-" * 50
-      to_run.each do |migration|
+      to_run_migrations.each do |migration|
         status = migrated.include?(migration.version.to_i) ? 'down' : 'up'
         puts "#{status.center(8)}  #{migration.version.to_s.ljust(14)}  #{migration.name}"
       end
@@ -408,6 +398,16 @@ module Mongoid #:nodoc
       runnable.pop if down? && !target.nil?
 
       runnable
+    end
+
+    def to_run_migrations
+      runnable_migrations.select do |migration|
+        if up?
+          !migrated.include?(migration.version.to_i)
+        elsif down?
+          migrated.include?(migration.version.to_i)
+        end
+      end
     end
 
     def migrated

--- a/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
+++ b/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
@@ -200,9 +200,9 @@ module Mongoid #:nodoc
 
       def status(migrations_path, target_version = nil)
         case
-          when target_version.nil?              then self.new(:up, migrations_path, target_version).status
-          when current_version > target_version then self.new(:down, migrations_path, target_version).status
-          else                                       self.new(:up, migrations_path, target_version).status
+          when target_version.nil?              then new(:up, migrations_path, target_version).status
+          when current_version > target_version then new(:down, migrations_path, target_version).status
+          else                                       new(:up, migrations_path, target_version).status
         end
       end
 

--- a/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
+++ b/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
@@ -198,6 +198,14 @@ module Mongoid #:nodoc
         end
       end
 
+      def status(migrations_path, target_version = nil)
+        case
+          when target_version.nil?              then self.new(:up, migrations_path, target_version).status
+          when current_version > target_version then self.new(:down, migrations_path, target_version).status
+          else                                       self.new(:up, migrations_path, target_version).status
+        end
+      end
+
       def rollback(migrations_path, steps=1)
         move(:down, migrations_path, steps)
       end
@@ -294,19 +302,7 @@ module Mongoid #:nodoc
     end
 
     def migrate
-      current = migrations.detect { |m| m.version == current_version }
-      target = migrations.detect { |m| m.version == @target_version }
-
-      if target.nil? && !@target_version.nil? && @target_version > 0
-        raise UnknownMigrationVersionError.new(@target_version)
-      end
-
-      start = up? ? 0 : (migrations.index(current) || 0)
-      finish = migrations.index(target) || migrations.size - 1
-      runnable = migrations[start..finish]
-
-      # skip the last migration if we're headed down, but not ALL the way down
-      runnable.pop if down? && !target.nil?
+      runnable = runnable_migrations
 
       runnable.each do |migration|
         Rails.logger.info "Migrating to #{migration.name} (#{migration.version})" if Rails.logger
@@ -335,6 +331,27 @@ module Mongoid #:nodoc
         rescue => e
           raise StandardError, "An error has occurred, #{migration.version} and all later migrations canceled:\n\n#{e}", e.backtrace
         end
+      end
+    end
+
+    def status
+      runnable = runnable_migrations
+
+      to_run = runnable.select do |migration|
+        if up?
+          !migrated.include?(migration.version.to_i)
+        elsif down?
+          migrated.include?(migration.version.to_i)
+        end
+      end
+
+      database_name = Migration.connection.options[:database]
+      puts "\ndatabase: #{database_name}\n\n"
+      puts "#{'Status'.center(8)}  #{'Migration ID'.ljust(14)}  Migration Name"
+      puts "-" * 50
+      to_run.each do |migration|
+        status = migrated.include?(migration.version.to_i) ? 'down' : 'up'
+        puts "#{status.center(8)}  #{migration.version.to_s.ljust(14)}  #{migration.name}"
       end
     end
 
@@ -373,6 +390,24 @@ module Mongoid #:nodoc
     def pending_migrations
       already_migrated = migrated
       migrations.reject { |m| already_migrated.include?(m.version.to_i) }
+    end
+
+    def runnable_migrations
+      current = migrations.detect { |m| m.version == current_version }
+      target = migrations.detect { |m| m.version == @target_version }
+
+      if target.nil? && !@target_version.nil? && @target_version > 0
+        raise UnknownMigrationVersionError.new(@target_version)
+      end
+
+      start = up? ? 0 : (migrations.index(current) || 0)
+      finish = migrations.index(target) || migrations.size - 1
+      runnable = migrations[start..finish]
+
+      # skip the last migration if we're headed down, but not ALL the way down
+      runnable.pop if down? && !target.nil?
+
+      runnable
     end
 
     def migrated

--- a/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
+++ b/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
@@ -71,6 +71,11 @@ namespace :db do
       raise "VERSION is required" unless version
       Mongoid::Migrator.run(:down, Mongoid::Migrator.migrations_path, version)
     end
+
+    desc 'Display status of migrations'
+    task :status => :environment do
+      Mongoid::Migrator.status("db/migrate/", ENV["VERSION"] ? ENV["VERSION"].to_i : nil)
+    end
   end
 
   desc 'Rolls the database back to the previous migration. Specify the number of steps with STEP=n'

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -170,52 +170,52 @@ module Mongoid
     end
 
     def test_status_up
-      output = <<~EOF
+      output = <<-EOF
 
-      database: mongoid_test
+database: mongoid_test
 
-       Status   Migration ID    Migration Name
-      --------------------------------------------------
-         up     20100513054656  AddBaselineSurveySchema
-         up     20100513055502  AddSecondSurveySchema
-         up     20100513063902  AddImprovementPlanSurveySchema
+ Status   Migration ID    Migration Name
+--------------------------------------------------
+   up     20100513054656  AddBaselineSurveySchema
+   up     20100513055502  AddSecondSurveySchema
+   up     20100513063902  AddImprovementPlanSurveySchema
       EOF
       assert_output(output) { Mongoid::Migrator.status(MIGRATIONS_ROOT + "/valid") }
     end
 
     def test_status_up_with_target
-      output = <<~EOF
+      output = <<-EOF
 
-      database: mongoid_test
+database: mongoid_test
 
-       Status   Migration ID    Migration Name
-      --------------------------------------------------
-         up     20100513054656  AddBaselineSurveySchema
+ Status   Migration ID    Migration Name
+--------------------------------------------------
+   up     20100513054656  AddBaselineSurveySchema
       EOF
       assert_output(output) { Mongoid::Migrator.status(MIGRATIONS_ROOT + "/valid", 20100513054656) }
     end
 
     def test_status_up_without_pending_migrations
       Mongoid::Migrator.migrate(MIGRATIONS_ROOT + "/valid")
-      output = <<~EOF
+      output = <<-EOF
 
-      database: mongoid_test
+database: mongoid_test
 
-       Status   Migration ID    Migration Name
-      --------------------------------------------------
+ Status   Migration ID    Migration Name
+--------------------------------------------------
       EOF
       assert_output(output) { Mongoid::Migrator.status(MIGRATIONS_ROOT + "/valid") }
     end
 
     def test_status_down
       Mongoid::Migrator.migrate(MIGRATIONS_ROOT + "/valid")
-      output = <<~EOF
+      output = <<-EOF
 
-      database: mongoid_test
+database: mongoid_test
 
-       Status   Migration ID    Migration Name
-      --------------------------------------------------
-        down    20100513063902  AddImprovementPlanSurveySchema
+ Status   Migration ID    Migration Name
+--------------------------------------------------
+  down    20100513063902  AddImprovementPlanSurveySchema
       EOF
       assert_output(output) { Mongoid::Migrator.status(MIGRATIONS_ROOT + "/valid", 20100513055502) }
     end

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -169,5 +169,56 @@ module Mongoid
       Mongoid::Migration.connection
     end
 
+    def test_status_up
+      output = <<~EOF
+
+      database: mongoid_test
+
+       Status   Migration ID    Migration Name
+      --------------------------------------------------
+         up     20100513054656  AddBaselineSurveySchema
+         up     20100513055502  AddSecondSurveySchema
+         up     20100513063902  AddImprovementPlanSurveySchema
+      EOF
+      assert_output(output) { Mongoid::Migrator.status(MIGRATIONS_ROOT + "/valid") }
+    end
+
+    def test_status_up_with_target
+      output = <<~EOF
+
+      database: mongoid_test
+
+       Status   Migration ID    Migration Name
+      --------------------------------------------------
+         up     20100513054656  AddBaselineSurveySchema
+      EOF
+      assert_output(output) { Mongoid::Migrator.status(MIGRATIONS_ROOT + "/valid", 20100513054656) }
+    end
+
+    def test_status_up_without_pending_migrations
+      Mongoid::Migrator.migrate(MIGRATIONS_ROOT + "/valid")
+      output = <<~EOF
+
+      database: mongoid_test
+
+       Status   Migration ID    Migration Name
+      --------------------------------------------------
+      EOF
+      assert_output(output) { Mongoid::Migrator.status(MIGRATIONS_ROOT + "/valid") }
+    end
+
+    def test_status_down
+      Mongoid::Migrator.migrate(MIGRATIONS_ROOT + "/valid")
+      output = <<~EOF
+
+      database: mongoid_test
+
+       Status   Migration ID    Migration Name
+      --------------------------------------------------
+        down    20100513063902  AddImprovementPlanSurveySchema
+      EOF
+      assert_output(output) { Mongoid::Migrator.status(MIGRATIONS_ROOT + "/valid", 20100513055502) }
+    end
+
   end
 end


### PR DESCRIPTION
This PR adds a `rake db:migrate:status` task listing pending migrations. It accepts an optionnal `VERSION` env variable which will be used as the targeted version (just like in `rake db:migrate`).

The output will look like this:
```
database: mongoid_test

 Status   Migration ID    Migration Name
--------------------------------------------------
   up     20100513054656  AddBaselineSurveySchema
   up     20100513055502  AddSecondSurveySchema
   up     20100513063902  AddImprovementPlanSurveySchema
```
This formating is inspired by [ActiveRecord rake db:migrate output](https://github.com/rails/rails/blob/master/activerecord/lib/active_record/tasks/database_tasks.rb#L205).