### PR TITLE
Fix db:migrate:status task to behave like the ActiveRecord version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ $ rails db:version
 ## Unreleased
 [Compare master with 1.1.1](https://github.com/adacosta/mongoid_rails_migrations/compare/v1.1.1...master)
 
+## 1.2.1
+_17/01/2019_
+* Fix on `db:migrate:status` task to behave like the `ActiveRecord` version (#47)
+
 ## 1.2.0
 _23/10/2018_
 * Added a `rollback_to` task to rollback to a particular version (#17)

--- a/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
+++ b/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
@@ -74,7 +74,7 @@ namespace :db do
 
     desc 'Display status of migrations'
     task :status => :environment do
-      Mongoid::Migrator.status("db/migrate/", ENV["VERSION"] ? ENV["VERSION"].to_i : nil)
+      Mongoid::Migrator.status("db/migrate/")
     end
   end
 

--- a/lib/mongoid_rails_migrations/version.rb
+++ b/lib/mongoid_rails_migrations/version.rb
@@ -1,3 +1,3 @@
 module MongoidRailsMigrations #:nodoc:
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end


### PR DESCRIPTION
#46 added a `rake db:migrate:status` task, but this task does not behave like the [ActiveRecord task](http://vaidehijoshi.github.io/blog/2015/05/19/the-secret-life-of-your-database-part-1-migrations/) it was inspired from.

Currently in this gem, the `rake db:migrate:status` task accepts a version parameter, and it'll print only the pending migration with an up/down status depending on the method which is going to be run on the migration if we execute the migrations with this version as a target.

The `ActiveRecord` counterpart is completely different. It does not accept a version parameter. It lists all the migrations and shows an up status if the migration was ran, and a down one if it needs to be run.

This PR changes the `rake db:migrate:status` task to mimic the `ActiveRecord` version behavior.
For example, with a first migration being already performed, and two following migrations not performed yet, the output will look like this:
```
database: mongoid_test

 Status   Migration ID    Migration Name
--------------------------------------------------
   up     20100513054656  AddBaselineSurveySchema
  down    20100513055502  AddSecondSurveySchema
  down    20100513063902  AddImprovementPlanSurveySchema
```

I bumped the version to `1.2.1`. It's not a backward compatible change since the behavior completely changes, but it's a rake task and not something from the API so I just bumped the patch part.