### PR TITLE
Document 'Mongoid::Migrator.migrations_path'

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,11 @@ $ rails db:reseed (handled by mongoid)
 $ rails db:version
 ```
 
+To override default migrations path (`db/migrate`), add next line to your `application.rb` file:
+```
+Mongoid::Migrator.migrations_path = ['foo/bar/db/migrate', 'path/to/db/migrate']
+```
+
 # Compatibility
 
 * `1.2.x` targets Mongoid >= `4.0.0` and Rails >= `4.2.0`

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ rails db:reseed (handled by mongoid)
 $ rails db:version
 ```
 
-To override default migrations path (`db/migrate`), add next line to your `application.rb` file:
+To override the default migrations path (`db/migrate`), add the following line to your `application.rb` file:
 ```
 Mongoid::Migrator.migrations_path = ['foo/bar/db/migrate', 'path/to/db/migrate']
 ```


### PR DESCRIPTION
Spent quite some time to realize how to override default `migrations_path`. Adding this to `README.md` can save some time for others.