### PR TITLE
Namespace config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,27 @@ To override the default migrations path (`db/migrate`), add the following line t
 Mongoid::Migrator.migrations_path = ['foo/bar/db/migrate', 'path/to/db/migrate']
 ```
 
-To override the default rake task namespace to avoid collision with `ActiveRecord` rake tasks, add the following line to your `application.rb` file:
+# Using along side ActiveRecord migrations
+If your rails app uses both `Mongoid` and `ActiveRecord` migrations then the migration files and rake tasks created by the two gems will cause conflict.
+In order to resolve this add the following lines to your `application.rb` file:
 ```
 Mongoid::Migrator.namespace = 'db:mongoid'
+Mongoid::Migrator.migrations_path = ['db/mongoid']
 ```
+With the above changes the generated migration files will be created under the `db/mongoid` path instead of the default `db/migrate` path and the rake tasks would change to:
+```
+$ rails db:mongoid:migrate
+$ rails db:mongoid:migrate:down VERSION=
+$ rails db:mongoid:migrate:up VERSION=
+$ rails db:mongoid:rollback
+$ rails db:mongoid:rollback_to VERSION=
+$ rails db:mongoid:migrate:redo
+$ rails db:mongoid:migrate:reset
+$ rails db:mongoid:migrate:status
+$ rails db:mongoid:reseed (handled by mongoid)
+$ rails db:mongoid:version
+```
+If there are pre-existing Mongoid migration files under the `db/migrate` path then they'll have to be moved manually to the new path.
 
 # Compatibility
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ To override the default migrations path (`db/migrate`), add the following line t
 Mongoid::Migrator.migrations_path = ['foo/bar/db/migrate', 'path/to/db/migrate']
 ```
 
+To override the default rake task namespace to avoid collision with `ActiveRecord` rake tasks, add the following line to your `application.rb` file:
+```
+Mongoid::Migrator.namespace = 'db:mongoid'
+```
+
 # Compatibility
 
 * `1.2.x` targets Mongoid >= `4.0.0` and Rails >= `4.2.0`

--- a/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
+++ b/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
@@ -189,6 +189,7 @@ module Mongoid #:nodoc
   class Migrator#:nodoc:
     class << self
       attr_writer :migrations_path
+      attr :namespace
 
       def migrate(migrations_path, target_version = nil)
         case
@@ -231,6 +232,14 @@ module Mongoid #:nodoc
 
       def migrations_path
         @migrations_path ||= ['db/migrate']
+      end
+
+      def namespace
+        @namespace ||= 'db'
+      end
+
+      def namespace=(val)
+        @namespace = val.to_s
       end
 
       # def schema_migrations_table_name

--- a/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
+++ b/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
@@ -1,12 +1,12 @@
-namespace :db do
-  unless Rake::Task.task_defined?("db:drop")
+namespace Mongoid::Migrator.namespace do
+  unless Rake::Task.task_defined?("#{Mongoid::Migrator.namespace}:drop")
     desc 'Drops all the collections for the database for the current Rails.env'
     task :drop => :environment do
       Mongoid.master.collections.each {|col| col.drop_indexes && col.drop unless ['system.indexes', 'system.users'].include?(col.name) }
     end
   end
 
-  unless Rake::Task.task_defined?("db:seed")
+  unless Rake::Task.task_defined?("#{Mongoid::Migrator.namespace}:seed")
     # if another ORM has defined db:seed, don't run it twice.
     desc 'Load the seed data from db/seeds.rb'
     task :seed => :environment do
@@ -15,17 +15,17 @@ namespace :db do
     end
   end
 
-  unless Rake::Task.task_defined?("db:setup")
+  unless Rake::Task.task_defined?("#{Mongoid::Migrator.namespace}:setup")
     desc 'Create the database, and initialize with the seed data'
     task :setup => [ 'db:create', 'db:seed' ]
   end
 
-  unless Rake::Task.task_defined?("db:reseed")
+  unless Rake::Task.task_defined?("#{Mongoid::Migrator.namespace}:reseed")
     desc 'Delete data and seed'
     task :reseed => [ 'db:drop', 'db:seed' ]
   end
 
-  unless Rake::Task.task_defined?("db:create")
+  unless Rake::Task.task_defined?("#{Mongoid::Migrator.namespace}:create")
     task :create => :environment do
       # noop
     end
@@ -46,17 +46,19 @@ namespace :db do
     desc  'Rollback the database one migration and re migrate up. If you want to rollback more than one step, define STEP=x. Target specific version with VERSION=x.'
     task :redo => :environment do
       if ENV["VERSION"]
-        Rake::Task["db:migrate:down"].invoke
-        Rake::Task["db:migrate:up"].invoke
+        Rake::Task["#{Mongoid::Migrator.namespace}:migrate:down"].invoke
+        Rake::Task["#{Mongoid::Migrator.namespace}:migrate:up"].invoke
       else
-        Rake::Task["db:rollback"].invoke
-        Rake::Task["db:migrate"].invoke
+        Rake::Task["#{Mongoid::Migrator.namespace}:rollback"].invoke
+        Rake::Task["#{Mongoid::Migrator.namespace}:migrate"].invoke
       end
     end
 
     desc 'Resets your database using your migrations for the current environment'
     # should db:create be changed to db:setup? It makes more sense wanting to seed
-    task :reset => ["db:drop", "db:create", "db:migrate"]
+    task :reset => ["#{Mongoid::Migrator.namespace}:drop",
+                    "#{Mongoid::Migrator.namespace}:create",
+                    "#{Mongoid::Migrator.namespace}:migrate"]
 
     desc 'Runs the "up" for a given migration VERSION.'
     task :up => :environment do

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -10,6 +10,7 @@ module Mongoid
   class TestCase < Minitest::Test #:nodoc:
 
     def setup
+      Mongoid::Migrator.migrations_path = ["db/migrate"]
       Mongoid::Migration.verbose = true
       Mongo::Logger.logger.level = 1
       # same as db:drop command in lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
@@ -229,5 +230,19 @@ database: mongoid_test
       assert_output(output) { Mongoid::Migrator.status(MIGRATIONS_ROOT + "/valid") }
     end
 
+  end
+
+  class NameSpaceTestCase < TestCase
+    def setup
+      Mongoid::Migrator.namespace = 'db:mongoid'
+      super
+      Mongoid::Migrator.migrations_path = ["db/mongoid"]
+    end
+
+    def test_migrations_path
+      assert_equal ["db/mongoid"], Mongoid::Migrator.migrations_path
+      Mongoid::Migrator.migrations_path += ["engines/my_engine/db/migrate"]
+      assert_equal ["db/mongoid", "engines/my_engine/db/migrate"], Mongoid::Migrator.migrations_path
+    end
   end
 end


### PR DESCRIPTION
Make rake task namespace to configurable so conflict with `ActiveRecord` rake tasks can be avoided