### PR TITLE
Better: Add hook after_migrate

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ To override the default migrations path (`db/migrate`), add the following line t
 Mongoid::Migrator.migrations_path = ['foo/bar/db/migrate', 'path/to/db/migrate']
 ```
 
+If you want to use output migration use the hook `after_migrate`
+```
+Mongoid::Migration.after_migrate = Proc.new do |output, name|
+  upload_to_s3(name, output)
+end
+```
+
 # Compatibility
 
 * `1.2.x` targets Mongoid >= `4.0` and Rails >= `4.2`
@@ -41,8 +48,11 @@ Mongoid::Migrator.migrations_path = ['foo/bar/db/migrate', 'path/to/db/migrate']
 # Changelog
 
 ## Unreleased
+
+## 1.3.0
 [Compare master with 1.2.1](https://github.com/adacosta/mongoid_rails_migrations/compare/v1.2.1...master)
 * Rake Tasks updated to use `migrations_path` instead of hardcoded path (#52)
+* Added `after_migrate` hook(#)
 
 ## 1.2.1
 _17/01/2019_

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Mongoid::Migrator.migrations_path = ['foo/bar/db/migrate', 'path/to/db/migrate']
 
 If you want to use output migration use the hook `after_migrate`
 ```
-Mongoid::Migration.after_migrate = Proc.new do |output, name|
-  upload_to_s3(name, output)
-end
+Mongoid::Migration.after_migrate = ->(output, name, direction) {
+  upload_to_s3(name, output, direction)
+}
 ```
 
 # Compatibility
@@ -52,7 +52,7 @@ end
 ## 1.3.0
 [Compare master with 1.2.1](https://github.com/adacosta/mongoid_rails_migrations/compare/v1.2.1...master)
 * Rake Tasks updated to use `migrations_path` instead of hardcoded path (#52)
-* Added `after_migrate` hook(#)
+* Added `after_migrate` hook(#54)
 
 ## 1.2.1
 _17/01/2019_

--- a/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
+++ b/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
@@ -92,7 +92,7 @@ module Mongoid #:nodoc
         begin
           @@after_migrate.call(@buffer_output, name) if @@after_migrate
         rescue => e
-          announce("Error in after_migrate hook: #{e}")
+          say("Error in after_migrate hook: #{e}")
         end
         result
       end
@@ -118,10 +118,8 @@ module Mongoid #:nodoc
 
       def write(text="")
         @buffer_output ||=  ""
-        if verbose
-          @buffer_output += text + "\n"
-          puts(text)
-        end
+        @buffer_output += text + "\n"
+        puts(text) if verbose
       end
 
       def announce(message)

--- a/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
+++ b/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
@@ -90,7 +90,7 @@ module Mongoid #:nodoc
         end
 
         begin
-          @@after_migrate.call(@buffer_output, name) if @@after_migrate
+          @@after_migrate.call(@buffer_output, name, direction) if @@after_migrate
         rescue => e
           say("Error in after_migrate hook: #{e}")
         end

--- a/lib/mongoid_rails_migrations/version.rb
+++ b/lib/mongoid_rails_migrations/version.rb
@@ -1,3 +1,3 @@
 module MongoidRailsMigrations #:nodoc:
-  VERSION = '1.2.1'
+  VERSION = '1.3.0'
 end

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -231,13 +231,12 @@ database: mongoid_test
 
     def test_hook_after_migration
       buffer = ""
-      Mongoid::Migration.after_migrate = Proc.new {
-        |output, name|
+      Mongoid::Migration.after_migrate = ->(output, name, direction) {
         buffer = output
       }
       Mongoid::Migrator.up(MIGRATIONS_ROOT + "/other_valid")
 
-      assert_match(/^==  AddOtherPlanSurveySchema: migrating =======================================\n==  AddOtherPlanSurveySchema: migrated \(.+s\) ==============================\n\n$/, buffer)
+      assert_match(/\A==  AddOtherPlanSurveySchema: migrating =======================================\n==  AddOtherPlanSurveySchema: migrated \(.+s\) ==============================\n\n\z/, buffer)
     end
 
   end

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -237,7 +237,7 @@ database: mongoid_test
       }
       Mongoid::Migrator.up(MIGRATIONS_ROOT + "/other_valid")
 
-      assert_match /\=\=  AddOtherPlanSurveySchema: migrating \=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\n\=\=  AddOtherPlanSurveySchema: migrated \(\d\.\d{1,4}s\)/, buffer
+      assert_match(/^==  AddOtherPlanSurveySchema: migrating =======================================\n==  AddOtherPlanSurveySchema: migrated \(.+s\) ==============================\n\n$/, buffer)
     end
 
   end

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -229,5 +229,16 @@ database: mongoid_test
       assert_output(output) { Mongoid::Migrator.status(MIGRATIONS_ROOT + "/valid") }
     end
 
+    def test_hook_after_migration
+      buffer = ""
+      Mongoid::Migration.after_migrate = Proc.new {
+        |output, name|
+        buffer = output
+      }
+      Mongoid::Migrator.up(MIGRATIONS_ROOT + "/other_valid")
+
+      assert_match /\=\=  AddOtherPlanSurveySchema: migrating \=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\=\n\=\=  AddOtherPlanSurveySchema: migrated \(\d\.\d{1,4}s\)/, buffer
+    end
+
   end
 end


### PR DESCRIPTION
We need to save the output of the migration.
I have added a hook named after_migrate which make available the log of the migration and the name.
I haven't added the test yet.
Could you make the first review to be sure the proposed solution is ok.