### PR TITLE
Add hook after_migrate when migration crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Mongoid::Migration.after_migrate = ->(output, name, direction, crash) {
 
 ## Unreleased
 
-## 1.3.1
+## 1.4.0
 _06/01/2021_
-* The hook `migrations_path` can be use when migration crash (#55)
+* The hook `migrations_path` can be use when migration crash (#56)
 
 ## 1.3.0
 [Compare master with 1.2.1](https://github.com/adacosta/mongoid_rails_migrations/compare/v1.2.1...master)

--- a/README.md
+++ b/README.md
@@ -50,11 +50,12 @@ Mongoid::Migration.after_migrate = ->(output, name, direction, crash) {
 ## Unreleased
 
 ## 1.4.0
-_06/01/2021_
-* The hook `migrations_path` can be use when migration crash (#56)
+_08/01/2021_
+[Compare master with 1.3.0](https://github.com/adacosta/mongoid_rails_migrations/compare/v1.3.0...master)
+* The hook `after_migrate` can be use when migration crash (#56)
 
 ## 1.3.0
-[Compare master with 1.2.1](https://github.com/adacosta/mongoid_rails_migrations/compare/v1.2.1...master)
+_17/12/2020_
 * Rake Tasks updated to use `migrations_path` instead of hardcoded path (#52)
 * Added `after_migrate` hook(#54)
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ Mongoid::Migrator.migrations_path = ['foo/bar/db/migrate', 'path/to/db/migrate']
 
 If you want to use output migration use the hook `after_migrate`
 ```
-Mongoid::Migration.after_migrate = ->(output, name, direction) {
-  upload_to_s3(name, output, direction)
+Mongoid::Migration.after_migrate = ->(output, name, direction, crash) {
+  upload_to_s3(name, output, direction) if crash == false
 }
 ```
 
@@ -48,6 +48,10 @@ Mongoid::Migration.after_migrate = ->(output, name, direction) {
 # Changelog
 
 ## Unreleased
+
+## 1.3.1
+_06/01/2021_
+* The hook `migrations_path` can be use when migration crash (#55)
 
 ## 1.3.0
 [Compare master with 1.2.1](https://github.com/adacosta/mongoid_rails_migrations/compare/v1.2.1...master)

--- a/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
+++ b/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
@@ -333,7 +333,7 @@ module Mongoid #:nodoc
           migration.migrate(@direction)
           record_version_state_after_migrating(migration.version)
         rescue => e
-          output = Migration.buffer_output + "An error has occurred, #{migration.version} and all later migrations canceled:\n\n#{e}"
+          output = Migration.buffer_output + "An error has occurred, #{migration.version} and all later migrations canceled:\n\n#{e}\n#{e.backtrace.join("\n")}"
           begin
             Migration.after_migrate.call(output, migration.name, @direction, true) if Migration.after_migrate
             Migration.buffer_output = nil

--- a/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
+++ b/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
@@ -61,7 +61,7 @@ module Mongoid #:nodoc
   #
   class Migration
     @@verbose = true
-    cattr_accessor :verbose, :after_migrate
+    cattr_accessor :verbose, :after_migrate, :buffer_output
 
     class << self
       def up_with_benchmarks #:nodoc:
@@ -90,7 +90,8 @@ module Mongoid #:nodoc
         end
 
         begin
-          @@after_migrate.call(@buffer_output, name, direction) if @@after_migrate
+          @@after_migrate.call(@@buffer_output, name, direction, false) if @@after_migrate
+          @@buffer_output = nil
         rescue => e
           say("Error in after_migrate hook: #{e}")
         end
@@ -117,8 +118,8 @@ module Mongoid #:nodoc
       end
 
       def write(text="")
-        @buffer_output ||=  ""
-        @buffer_output += text + "\n"
+        @@buffer_output ||=  ""
+        @@buffer_output += text + "\n"
         puts(text) if verbose
       end
 
@@ -332,6 +333,13 @@ module Mongoid #:nodoc
           migration.migrate(@direction)
           record_version_state_after_migrating(migration.version)
         rescue => e
+          output = Migration.buffer_output + "An error has occurred, #{migration.version} and all later migrations canceled:\n\n#{e}"
+          begin
+            Migration.after_migrate.call(output, migration.name, @direction, true) if Migration.after_migrate
+            Migration.buffer_output = nil
+          rescue => error
+            puts("Error in after_migrate hook: #{error}")
+          end
           raise StandardError, "An error has occurred, #{migration.version} and all later migrations canceled:\n\n#{e}", e.backtrace
         end
       end

--- a/lib/mongoid_rails_migrations/version.rb
+++ b/lib/mongoid_rails_migrations/version.rb
@@ -1,3 +1,3 @@
 module MongoidRailsMigrations #:nodoc:
-  VERSION = '1.3.0'
+  VERSION = '1.4.0'
 end

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -247,7 +247,7 @@ database: mongoid_test
       assert_raises (StandardError) do
         Mongoid::Migrator.up(MIGRATIONS_ROOT + "/crash")
       end
-      assert_match(/\A==  BasicCrash: migrating =====================================================\nAn error has occurred, 20210105165947 and all later migrations canceled:\n\nCrash migration\z/, buffer)
+      assert_match(/\A==  BasicCrash: migrating =====================================================\nAn error has occurred, 20210105165947 and all later migrations canceled:\n\nCrash migration\n.*test/, buffer)
     end
   end
 end

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -231,7 +231,7 @@ database: mongoid_test
 
     def test_hook_after_migration
       buffer = ""
-      Mongoid::Migration.after_migrate = ->(output, name, direction) {
+      Mongoid::Migration.after_migrate = ->(output, name, direction, crash) {
         buffer = output
       }
       Mongoid::Migrator.up(MIGRATIONS_ROOT + "/other_valid")
@@ -239,5 +239,15 @@ database: mongoid_test
       assert_match(/\A==  AddOtherPlanSurveySchema: migrating =======================================\n==  AddOtherPlanSurveySchema: migrated \(.+s\) ==============================\n\n\z/, buffer)
     end
 
+    def test_hook_when_migration_crash
+      buffer = ""
+      Mongoid::Migration.after_migrate = ->(output, name, direction, crash) {
+        buffer = output if crash == true
+      }
+      assert_raises (StandardError) do
+        Mongoid::Migrator.up(MIGRATIONS_ROOT + "/crash")
+      end
+      assert_match(/\A==  BasicCrash: migrating =====================================================\nAn error has occurred, 20210105165947 and all later migrations canceled:\n\nCrash migration\z/, buffer)
+    end
   end
 end

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -247,7 +247,7 @@ database: mongoid_test
       assert_raises (StandardError) do
         Mongoid::Migrator.up(MIGRATIONS_ROOT + "/crash")
       end
-      assert_match(/\A==  BasicCrash: migrating =====================================================\nAn error has occurred, 20210105165947 and all later migrations canceled:\n\nCrash migration\n.*test/, buffer)
+      assert_match(/\A==  BasicCrash: migrating =====================================================\nAn error has occurred, 20210105165947 and all later migrations canceled:\n\nCrash migration\n.*\/test\/migrations\/crash\/20210105165947_basic_crash.rb:3:in `up'\n/, buffer)
     end
   end
 end

--- a/test/migrations/crash/20210105165947_basic_crash.rb
+++ b/test/migrations/crash/20210105165947_basic_crash.rb
@@ -1,0 +1,9 @@
+class BasicCrash < Mongoid::Migration
+  def self.up
+    raise "Crash migration"
+  end
+
+  def self.down
+    raise "Crash reverting"
+  end
+end


### PR DESCRIPTION
Add the hook 'after_migrate' when migration crash.
Before the hook 'after_migrate' don't work when migration crash.
Now when the migration crash he keep output.