### PR TITLE
Add option to enable shards migrations as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,16 @@ The shards migrations will be executed and entries will be added in the `my_shar
 
 All the rake tasks support the `MONGOID_CLIENT_NAME` environment variable.
 
+To make shards migrations the default migration type, add the following line in your config:
+
+```ruby
+# config/application.rb
+
+Mongoid.configure.shards_migration_as_default = true
+```
+
+Global migrations can still be created with the `--no-shards` option.
+
 # Compatibility
 
 * `1.5.x` targets Mongoid >= `5.0` and Rails >= `4.2`

--- a/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
+++ b/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
@@ -55,7 +55,7 @@ module Mongoid #:nodoc
   # If you'd prefer to use numeric prefixes, you can turn timestamped migrations
   # off by setting:
   #
-  #    Mongoid.config.timestamped_migrations = false
+  #    Mongoid.configure.timestamped_migrations = false
   #
   # In environment.rb.
   #

--- a/lib/mongoid_rails_migrations/mongoid_ext/mongoid.rb
+++ b/lib/mongoid_rails_migrations/mongoid_ext/mongoid.rb
@@ -1,21 +1,7 @@
 # encoding: utf-8
 module Mongoid
   # Specify whether or not to use timestamps for migration versions
-  # NOTE: newer style is a module
-  # Config.module_eval would work for both but still need to determine the type
-  # that's why we do it the ug way.
-  if Config.is_a? Class
-    # older mongoid style; pre 2.0.0.rc.1
-    Config.module_eval do
-      cattr_accessor :timestamped_migrations
-      class_variable_set(:@@timestamped_migrations, true) unless class_variable_get(:@@timestamped_migrations)
-
-      def self.reset
-        @@timestamped_migrations = true
-      end
-    end
-  else # module
-    # newer mongoid style; >= 2.0.0.rc.1
-    Config.option :timestamped_migrations, :default => true
-  end
+  Config.option :timestamped_migrations, default: true
+  # Specify whether or not to use shards migrations as default type
+  Config.option :shards_migration_as_default, default: false
 end

--- a/lib/rails/generators/mongoid/migration/migration_generator.rb
+++ b/lib/rails/generators/mongoid/migration/migration_generator.rb
@@ -7,7 +7,7 @@ module Mongoid
 
       def create_migration_file
         destination_folder = "db/migrate"
-        if options[:shards]
+        if options.fetch(:shards, Config.shards_migration_as_default)
           destination_folder = "#{destination_folder}/shards"
           FileUtils.mkdir_p("#{Rails.root}/#{destination_folder}")
         end


### PR DESCRIPTION
This MR add support of a new `shards_migration_as_default` option allowing to make the shards migration the default migration type created by the generator.

Example:

```
# config/application.rb
Mongoid.configure.shards_migration_as_default = true

$ rails generate migration my_migration # => db/migrate/shards/20210409121815_my_migration.rb
$ rails generate migration my_migration --no-shards # => db/migrate/20210409121815_my_migration.rb
```
This option is disabled by default.