### PR TITLE
Remove drop, etc. rake tasks

### DIFF
--- a/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
+++ b/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
@@ -1,38 +1,4 @@
 namespace :db do
-  if Rake::Task.task_defined?("db:drop")
-    Rake::Task["db:drop"].clear
-  end
-
-  desc 'Drops all the collections for the database for the current Rails.env'
-  task :drop => :environment do
-    Mongoid::Migration.connection.database.drop
-  end
-
-  unless Rake::Task.task_defined?("db:seed")
-    # if another ORM has defined db:seed, don't run it twice.
-    desc 'Load the seed data from db/seeds.rb'
-    task :seed => :environment do
-      seed_file = File.join(Rails.application.root, 'db', 'seeds.rb')
-      load(seed_file) if File.exist?(seed_file)
-    end
-  end
-
-  unless Rake::Task.task_defined?("db:setup")
-    desc 'Create the database, and initialize with the seed data'
-    task :setup => [ 'db:create', 'db:seed' ]
-  end
-
-  unless Rake::Task.task_defined?("db:reseed")
-    desc 'Delete data and seed'
-    task :reseed => [ 'db:drop', 'db:seed' ]
-  end
-
-  unless Rake::Task.task_defined?("db:create")
-    task :create => :environment do
-      # noop
-    end
-  end
-
   desc 'Current database version'
   task :version => :environment do
     puts Mongoid::Migrator.current_version.to_s
@@ -55,10 +21,6 @@ namespace :db do
         Rake::Task["db:migrate"].invoke
       end
     end
-
-    desc 'Resets your database using your migrations for the current environment'
-    # should db:create be changed to db:setup? It makes more sense wanting to seed
-    task :reset => ["db:drop", "db:create", "db:migrate"]
 
     desc 'Runs the "up" for a given migration VERSION.'
     task :up => :environment do
@@ -91,17 +53,5 @@ namespace :db do
     version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
     raise "VERSION is required" unless version
     Mongoid::Migrator.rollback_to(Mongoid::Migrator.migrations_path, version)
-  end
-
-  namespace :schema do
-    task :load do
-      # noop
-    end
-  end
-
-  namespace :test do
-    task :prepare do
-      # Stub out for MongoDB
-    end
   end
 end

--- a/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
+++ b/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
@@ -22,6 +22,10 @@ namespace :db do
       end
     end
 
+    desc 'Resets your database using your migrations for the current environment'
+    # should db:create be changed to db:setup? It makes more sense wanting to seed
+    task :reset => ["db:drop", "db:create", "db:migrate"]
+
     desc 'Runs the "up" for a given migration VERSION.'
     task :up => :environment do
       version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil


### PR DESCRIPTION
This gem seems to be adding Rake tasks like `db:drop` which are:
(a) already provided by Mongoid
(b) beyond the scope of of what a "migrations" gem should do
(c) potentially dangerous

I've removed all rake tasks which are not directly related to migrations.