### PR TITLE
feat: customize rake namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,21 @@ $ rails generate mongoid:migration <your_migration_name_here>
 
 Run migrations:
 ```console
-$ rails db:migrate
-$ rails db:migrate:down VERSION=
-$ rails db:migrate:up VERSION=
-$ rails db:rollback
-$ rails db:rollback_to VERSION=
-$ rails db:migrate:redo
-$ rails db:migrate:reset
-$ rails db:migrate:status
-$ rails db:reseed (handled by mongoid)
-$ rails db:version
+$ rails db:mongoid:migrate
+$ rails db:mongoid:migrate:down VERSION=
+$ rails db:mongoid:migrate:up VERSION=
+$ rails db:mongoid:rollback
+$ rails db:mongoid:rollback_to VERSION=
+$ rails db:mongoid:migrate:redo
+$ rails db:mongoid:migrate:reset
+$ rails db:mongoid:migrate:status
+$ rails db:mongoid:version
 ```
+
+> [!NOTE]  
+> The gem will also bind most tasks to the default `db` namespace (e.g. `db:migrate`) if they are not already defined. This is for better compatibility with existing code and
+tools. It is recommended to use `db:mongoid:migrate` as the preferred option though, for better consistency with Mongoid default tasks, expliciteness and stability (e.g. if
+you add ActiveRecord later).
 
 If you want to use output migration use the hook `after_migrate`
 ```ruby

--- a/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
+++ b/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
@@ -1,70 +1,115 @@
 namespace :db do
-  if Rake::Task.task_defined?("db:drop")
-    Rake::Task["db:drop"].clear
+  namespace :mongoid do
+    if Rake::Task.task_defined?("db:mongoid:drop")
+      Rake::Task["db:mongoid:drop"].clear
+    end
+
+    desc 'Drops the database for the current Mongoid client'
+    task :drop => :environment do
+      # Unlike Mongoid's default, this implementation supports the MONGOID_CLIENT_NAME override
+      Mongoid::Migration.connection.database.drop
+    end
+
+    desc 'Current database version'
+    task :version => :environment do
+      puts Mongoid::Migrator.current_version.to_s
+    end
+
+    desc 'Rolls the database back to the previous migration. Specify the number of steps with STEP=n'
+    task :rollback => :environment do
+      step = ENV['STEP'] ? ENV['STEP'].to_i : 1
+      Mongoid::Migrator.rollback(Mongoid::Migrator.migrations_path, step)
+    end
+
+    desc 'Rolls the database back to the specified VERSION'
+    task :rollback_to => :environment do
+      version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
+      raise "VERSION is required" unless version
+      Mongoid::Migrator.rollback_to(Mongoid::Migrator.migrations_path, version)
+    end
+
+    desc "Migrate the database through scripts in db/migrate. Target specific version with VERSION=x. Turn off output with VERBOSE=false."
+    task :migrate => :environment do
+      Mongoid::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
+      Mongoid::Migrator.migrate(Mongoid::Migrator.migrations_path, ENV["VERSION"] ? ENV["VERSION"].to_i : nil)
+    end
+
+    namespace :migrate do
+      desc 'Rollback the database one migration and re migrate up. If you want to rollback more than one step, define STEP=x. Target specific version with VERSION=x.'
+      task :redo => :environment do
+        if ENV["VERSION"]
+          Rake::Task["db:mongoid:migrate:down"].invoke
+          Rake::Task["db:mongoid:migrate:up"].invoke
+        else
+          Rake::Task["db:mongoid:rollback"].invoke
+          Rake::Task["db:mongoid:migrate"].invoke
+        end
+      end
+
+      desc 'Resets your database using your migrations for the current environment'
+      task :reset => ["db:mongoid:drop", "db:mongoid:migrate"]
+
+      desc 'Runs the "up" for a given migration VERSION.'
+      task :up => :environment do
+        version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
+        raise "VERSION is required" unless version
+        Mongoid::Migrator.run(:up, Mongoid::Migrator.migrations_path, version)
+      end
+
+      desc 'Runs the "down" for a given migration VERSION.'
+      task :down => :environment do
+        version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
+        raise "VERSION is required" unless version
+        Mongoid::Migrator.run(:down, Mongoid::Migrator.migrations_path, version)
+      end
+
+      desc 'Display status of migrations'
+      task :status => :environment do
+        Mongoid::Migrator.status(Mongoid::Migrator.migrations_path)
+      end
+    end
   end
 
-  desc 'Drops the database for the current Mongoid client'
-  task :drop => :environment do
-    # Unlike Mongoid's default, this implementation supports the MONGOID_CLIENT_NAME override
-    Mongoid::Migration.connection.database.drop
+  unless Rake::Task.task_defined?("db:version")
+    desc '[DEPRECATED] Use "db:mongoid:version" instead.'
+    task :version => "db:mongoid:version"
   end
 
-  desc 'Current database version'
-  task :version => :environment do
-    puts Mongoid::Migrator.current_version.to_s
-  end
+  unless Rake::Task.task_defined?("db:rollback")
+    desc '[DEPRECATED] Use "db:mongoid:rollback" instead.'
+    task :rollback => "db:mongoid:rollback"
 
-  desc "Migrate the database through scripts in db/migrate. Target specific version with VERSION=x. Turn off output with VERBOSE=false."
-  task :migrate => :environment do
-    Mongoid::Migration.verbose = ENV["VERBOSE"] ? ENV["VERBOSE"] == "true" : true
-    Mongoid::Migrator.migrate(Mongoid::Migrator.migrations_path, ENV["VERSION"] ? ENV["VERSION"].to_i : nil)
+    desc '[DEPRECATED] Use "db:mongoid:rollback_to" instead.'
+    task :rollback_to => "db:mongoid:rollback_to"
+
+    desc '[DEPRECATED] Use "db:mongoid:migrate" instead.'
+    task :migrate => "db:mongoid:migrate"
   end
 
   namespace :migrate do
-    desc 'Rollback the database one migration and re migrate up. If you want to rollback more than one step, define STEP=x. Target specific version with VERSION=x.'
-    task :redo => :environment do
-      if ENV["VERSION"]
-        Rake::Task["db:migrate:down"].invoke
-        Rake::Task["db:migrate:up"].invoke
-      else
-        Rake::Task["db:rollback"].invoke
-        Rake::Task["db:migrate"].invoke
-      end
+    unless Rake::Task.task_defined?("db:migrate:redo")
+      desc '[DEPRECATED] Use "db:mongoid:migrate:redo" instead.'
+      task :redo => "db:mongoid:migrate:redo"
     end
 
-    desc 'Resets your database using your migrations for the current environment'
-    task :reset => ["db:drop", "db:migrate"]
-
-    desc 'Runs the "up" for a given migration VERSION.'
-    task :up => :environment do
-      version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
-      raise "VERSION is required" unless version
-      Mongoid::Migrator.run(:up, Mongoid::Migrator.migrations_path, version)
+    unless Rake::Task.task_defined?("db:migrate:reset")
+      desc '[DEPRECATED] Use "db:mongoid:migrate:reset" instead.'
+      task :reset => "db:mongoid:migrate:reset"
     end
 
-    desc 'Runs the "down" for a given migration VERSION.'
-    task :down => :environment do
-      version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
-      raise "VERSION is required" unless version
-      Mongoid::Migrator.run(:down, Mongoid::Migrator.migrations_path, version)
+    unless Rake::Task.task_defined?("db:migrate:up")
+      desc '[DEPRECATED] Use "db:mongoid:migrate:up" instead.'
+      task :up => "db:mongoid:migrate:up"
     end
 
-    desc 'Display status of migrations'
-    task :status => :environment do
-      Mongoid::Migrator.status(Mongoid::Migrator.migrations_path)
+    unless Rake::Task.task_defined?("db:migrate:down")
+      desc '[DEPRECATED] Use "db:mongoid:migrate:down" instead.'
+      task :down => "db:mongoid:migrate:down"
     end
-  end
 
-  desc 'Rolls the database back to the previous migration. Specify the number of steps with STEP=n'
-  task :rollback => :environment do
-    step = ENV['STEP'] ? ENV['STEP'].to_i : 1
-    Mongoid::Migrator.rollback(Mongoid::Migrator.migrations_path, step)
-  end
-
-  desc 'Rolls the database back to the specified VERSION'
-  task :rollback_to => :environment do
-    version = ENV["VERSION"] ? ENV["VERSION"].to_i : nil
-    raise "VERSION is required" unless version
-    Mongoid::Migrator.rollback_to(Mongoid::Migrator.migrations_path, version)
+    unless Rake::Task.task_defined?("db:migrate:status")
+      desc '[DEPRECATED] Use "db:mongoid:migrate:status" instead.'
+      task :status => "db:mongoid:migrate:status"
+    end
   end
 end

--- a/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
+++ b/lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake
@@ -33,8 +33,7 @@ namespace :db do
     end
 
     desc 'Resets your database using your migrations for the current environment'
-    # should db:create be changed to db:setup? It makes more sense wanting to seed
-    task :reset => ["db:drop", "db:create", "db:migrate"]
+    task :reset => ["db:drop", "db:migrate"]
 
     desc 'Runs the "up" for a given migration VERSION.'
     task :up => :environment do

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -4,9 +4,9 @@ module Mongoid
   class TestCase < Minitest::Test #:nodoc:
 
     def setup
-      invoke("db:drop")
+      invoke("db:mongoid:drop")
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:drop")
+        invoke("db:mongoid:drop")
       end
     end
 
@@ -15,7 +15,7 @@ module Mongoid
     end
 
     def test_drop_works
-      assert_equal 0, Mongoid::Migrator.current_version, "db:drop should take us down to version 0"
+      assert_equal 0, Mongoid::Migrator.current_version, "db:mongoid:drop should take us down to version 0"
     end
 
     def test_migrations_path

--- a/test/tasks/down_task_test.rb
+++ b/test/tasks/down_task_test.rb
@@ -3,12 +3,12 @@ require_relative './task_test_base'
 module Mongoid
   class DownTaskTest < TaskTestBase
     def test_database_migrate_down_raise_without_version
-      assert_raises { invoke("db:migrate:down") }
+      assert_raises { invoke("db:mongoid:migrate:down") }
     end
 
     def test_database_migrate_down
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      invoke("db:migrate")
+      invoke("db:mongoid:migrate")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -19,9 +19,9 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("db:mongoid:migrate:status") }
       with_env("VERSION" => "20100513055502") do
-        invoke("db:migrate:down")
+        invoke("db:mongoid:migrate:down")
       end
       assert_output(<<-EOF
 
@@ -33,14 +33,14 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("db:mongoid:migrate:status") }
     end
 
     def test_multidatabase_migrate_down
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
+      invoke("db:mongoid:migrate")
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
+        invoke("db:mongoid:migrate")
       end
 
       output = <<-EOF
@@ -52,7 +52,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       output = <<-EOF
 
 database: mongoid_test_s1
@@ -64,10 +64,10 @@ database: mongoid_test_s1
 EOF
 
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
       end
       with_env("VERSION" => "20210210125000") do
-        invoke("db:migrate:down")
+        invoke("db:mongoid:migrate:down")
       end
       output = <<-EOF
 
@@ -79,7 +79,7 @@ database: mongoid_test_s1
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -90,7 +90,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
         assert_equal(1, DataMigration.count)
       Mongoid::Migrator.with_mongoid_client("shard1") do
         assert_equal(2, DataMigration.count)
@@ -99,9 +99,9 @@ EOF
 
     def test_multidatabase_migrate_down_on_target_client
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
+      invoke("db:mongoid:migrate")
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
+        invoke("db:mongoid:migrate")
       end
 
       output = <<-EOF
@@ -113,7 +113,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       output = <<-EOF
 
 database: mongoid_test_s1
@@ -125,8 +125,8 @@ database: mongoid_test_s1
 EOF
 
       with_env("MONGOID_CLIENT_NAME" => "shard1", "VERSION" => "20210210124656") do
-        assert_output(output) { invoke("db:migrate:status") }
-        invoke("db:migrate:down")
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
+        invoke("db:mongoid:migrate:down")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -136,7 +136,7 @@ database: mongoid_test_s1
   down    20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -147,7 +147,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       assert_equal(2, DataMigration.count)
       Mongoid::Migrator.with_mongoid_client("shard1") do
         assert_equal(1, DataMigration.count)

--- a/test/tasks/drop_task_test.rb
+++ b/test/tasks/drop_task_test.rb
@@ -4,37 +4,37 @@ module Mongoid
   class DropTaskTest < TaskTestBase
     def test_drop_database
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      invoke("db:migrate")
-      assert_output("20100513063902\n") { invoke("db:version") }
-      invoke("db:drop")
-      assert_output("0\n") { invoke("db:version") }
+      invoke("db:mongoid:migrate")
+      assert_output("20100513063902\n") { invoke("db:mongoid:version") }
+      invoke("db:mongoid:drop")
+      assert_output("0\n") { invoke("db:mongoid:version") }
     end
 
     def test_drop_multidatabase
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
-      assert_output("20210210125800\n") { invoke("db:version") }
+      invoke("db:mongoid:migrate")
+      assert_output("20210210125800\n") { invoke("db:mongoid:version") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
-        assert_output("20210210125532\n") { invoke("db:version") }
+        invoke("db:mongoid:migrate")
+        assert_output("20210210125532\n") { invoke("db:mongoid:version") }
       end
-      invoke("db:drop")
-      assert_output("0\n") { invoke("db:version") }
-      with_env("MONGOID_CLIENT_NAME" => "shard1") { assert_output("20210210125532\n") { invoke("db:version") } }
+      invoke("db:mongoid:drop")
+      assert_output("0\n") { invoke("db:mongoid:version") }
+      with_env("MONGOID_CLIENT_NAME" => "shard1") { assert_output("20210210125532\n") { invoke("db:mongoid:version") } }
     end
 
 
     def test_drop_multidatabase_on_target_client
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
-      assert_output("20210210125800\n") { invoke("db:version") }
+      invoke("db:mongoid:migrate")
+      assert_output("20210210125800\n") { invoke("db:mongoid:version") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
-        assert_output("20210210125532\n") { invoke("db:version") }
-        invoke("db:drop")
-        assert_output("0\n") { invoke("db:version") }
+        invoke("db:mongoid:migrate")
+        assert_output("20210210125532\n") { invoke("db:mongoid:version") }
+        invoke("db:mongoid:drop")
+        assert_output("0\n") { invoke("db:mongoid:version") }
       end
-      assert_output("20210210125800\n") { invoke("db:version") }
+      assert_output("20210210125800\n") { invoke("db:mongoid:version") }
     end
   end
 end

--- a/test/tasks/migrate_task_test.rb
+++ b/test/tasks/migrate_task_test.rb
@@ -14,8 +14,8 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      invoke("db:migrate")
+      ) { invoke("db:mongoid:migrate:status") }
+      invoke("db:mongoid:migrate")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -26,7 +26,7 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("db:mongoid:migrate:status") }
     end
 
     def test_database_migrate_with_version
@@ -41,8 +41,8 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      with_env("VERSION" => "20100513055502") { invoke("db:migrate") }
+      ) { invoke("db:mongoid:migrate:status") }
+      with_env("VERSION" => "20100513055502") { invoke("db:mongoid:migrate") }
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -53,7 +53,7 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("db:mongoid:migrate:status") }
     end
 
 
@@ -68,7 +68,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       output = <<-EOF
 
 database: mongoid_test_s1
@@ -79,9 +79,9 @@ database: mongoid_test_s1
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
 
-      invoke("db:migrate")
+      invoke("db:mongoid:migrate")
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -92,7 +92,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       assert_equal(2, DataMigration.count)
       assert_equal(2, SurveySchema.count)
       Mongoid::Migrator.with_mongoid_client("shard1") do
@@ -112,7 +112,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       output = <<-EOF
 
 database: mongoid_test_s1
@@ -124,8 +124,8 @@ database: mongoid_test_s1
 EOF
 
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        assert_output(output) { invoke("db:migrate:status") }
-        invoke("db:migrate")
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
+        invoke("db:mongoid:migrate")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -135,7 +135,7 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -146,7 +146,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       assert_equal(0, DataMigration.count)
       Mongoid::Migrator.with_mongoid_client("shard1") do
         assert_equal(2, DataMigration.count)

--- a/test/tasks/redo_task_test.rb
+++ b/test/tasks/redo_task_test.rb
@@ -4,9 +4,9 @@ module Mongoid
   class RedoTaskTest < TaskTestBase
     def test_database_migrate_redo
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      invoke("db:migrate")
+      invoke("db:mongoid:migrate")
       with_env("VERSION" => "20100513055502") do
-        invoke("db:migrate:down")
+        invoke("db:mongoid:migrate:down")
       end
       assert_output(<<-EOF
 
@@ -18,8 +18,8 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      invoke("db:migrate:redo")
+      ) { invoke("db:mongoid:migrate:status") }
+      invoke("db:mongoid:migrate:redo")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -30,14 +30,14 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("db:mongoid:migrate:status") }
     end
 
     def test_database_migrate_redo_version
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      invoke("db:migrate")
+      invoke("db:mongoid:migrate")
       with_env("VERSION" => "20100513063902") do
-        invoke("db:migrate:down")
+        invoke("db:mongoid:migrate:down")
       end
       assert_output(<<-EOF
 
@@ -49,8 +49,8 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      with_env("VERSION" => "20100513055502") { invoke("db:migrate:redo") }
+      ) { invoke("db:mongoid:migrate:status") }
+      with_env("VERSION" => "20100513055502") { invoke("db:mongoid:migrate:redo") }
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -61,12 +61,12 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("db:mongoid:migrate:status") }
     end
 
     def test_multidatabase_redo
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
+      invoke("db:mongoid:migrate")
       output = <<-EOF
 
 database: mongoid_test
@@ -76,7 +76,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
         assert_output(<<-EOF
 
@@ -87,9 +87,9 @@ database: mongoid_test_s1
   down    20210210124656  ShardDatabaseMigration
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
-        ) { invoke("db:migrate:status") }
+        ) { invoke("db:mongoid:migrate:status") }
       end
-      invoke("db:migrate:redo")
+      invoke("db:mongoid:migrate:redo")
       output = <<-EOF
 
 database: mongoid_test
@@ -99,7 +99,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
         assert_output(<<-EOF
 
@@ -110,7 +110,7 @@ database: mongoid_test_s1
   down    20210210124656  ShardDatabaseMigration
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
-        ) { invoke("db:migrate:status") }
+        ) { invoke("db:mongoid:migrate:status") }
       end
     end
 
@@ -125,9 +125,9 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
+        invoke("db:mongoid:migrate")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -137,9 +137,9 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
-        invoke("db:migrate:redo")
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
+        invoke("db:mongoid:migrate:redo")
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -150,7 +150,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
     end
   end
 end

--- a/test/tasks/reset_task_test.rb
+++ b/test/tasks/reset_task_test.rb
@@ -4,9 +4,9 @@ module Mongoid
   class ResetTaskTest < TaskTestBase
     def test_database_migrate_reset
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      invoke("db:migrate")
+      invoke("db:mongoid:migrate")
       with_env("VERSION" => "20100513055502") do
-         invoke("db:migrate:down")
+         invoke("db:mongoid:migrate:down")
       end
       assert_output(<<-EOF
 
@@ -18,8 +18,8 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      invoke("db:migrate:reset")
+      ) { invoke("db:mongoid:migrate:status") }
+      invoke("db:mongoid:migrate:reset")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -30,12 +30,12 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("db:mongoid:migrate:status") }
     end
 
     def test_multidatabase_migrate_reset
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
+      invoke("db:mongoid:migrate")
       output = <<-EOF
 
 database: mongoid_test
@@ -45,7 +45,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
         assert_output(<<-EOF
 
@@ -56,9 +56,9 @@ database: mongoid_test_s1
   down    20210210124656  ShardDatabaseMigration
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
-        ) { invoke("db:migrate:status") }
+        ) { invoke("db:mongoid:migrate:status") }
       end
-      invoke("db:migrate:reset")
+      invoke("db:mongoid:migrate:reset")
       output = <<-EOF
 
 database: mongoid_test
@@ -68,7 +68,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
         assert_output(<<-EOF
 
@@ -79,7 +79,7 @@ database: mongoid_test_s1
   down    20210210124656  ShardDatabaseMigration
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
-        ) { invoke("db:migrate:status") }
+        ) { invoke("db:mongoid:migrate:status") }
       end
     end
 
@@ -94,9 +94,9 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
+        invoke("db:mongoid:migrate")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -106,9 +106,9 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
-        invoke("db:migrate:reset")
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
+        invoke("db:mongoid:migrate:reset")
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -119,7 +119,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
     end
   end
 end

--- a/test/tasks/rollback_test.rb
+++ b/test/tasks/rollback_test.rb
@@ -4,7 +4,7 @@ module Mongoid
   class RollbackTest < TaskTestBase
     def test_database_rollback
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      invoke("db:migrate")
+      invoke("db:mongoid:migrate")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -15,8 +15,8 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      invoke("db:rollback")
+      ) { invoke("db:mongoid:migrate:status") }
+      invoke("db:mongoid:rollback")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -27,12 +27,12 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("db:mongoid:migrate:status") }
     end
 
     def test_database_rollback_step
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      invoke("db:migrate")
+      invoke("db:mongoid:migrate")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -43,8 +43,8 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      with_env("STEP" => "2") { invoke("db:rollback") }
+      ) { invoke("db:mongoid:migrate:status") }
+      with_env("STEP" => "2") { invoke("db:mongoid:rollback") }
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -55,12 +55,12 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("db:mongoid:migrate:status") }
     end
 
     def test_multidatabase_rollback
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
+      invoke("db:mongoid:migrate")
       output = <<-EOF
 
 database: mongoid_test
@@ -70,9 +70,9 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
+        invoke("db:mongoid:migrate")
         assert_output(<<-EOF
 
 database: mongoid_test_s1
@@ -82,9 +82,9 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        ) { invoke("db:migrate:status") }
+        ) { invoke("db:mongoid:migrate:status") }
       end
-      invoke("db:rollback")
+      invoke("db:mongoid:rollback")
       output = <<-EOF
 
 database: mongoid_test
@@ -94,7 +94,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
         assert_output(<<-EOF
 
@@ -105,13 +105,13 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        ) { invoke("db:migrate:status") }
+        ) { invoke("db:mongoid:migrate:status") }
       end
     end
 
     def test_multidatabase_rollback_on_client_target
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
+      invoke("db:mongoid:migrate")
       output = <<-EOF
 
 database: mongoid_test
@@ -121,9 +121,9 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
+        invoke("db:mongoid:migrate")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -133,8 +133,8 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
-        invoke("db:rollback")
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
+        invoke("db:mongoid:rollback")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -144,7 +144,7 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -155,7 +155,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
     end
   end
 end

--- a/test/tasks/rollback_to_test.rb
+++ b/test/tasks/rollback_to_test.rb
@@ -3,12 +3,12 @@ require_relative './task_test_base'
 module Mongoid
   class RollbackToTest < TaskTestBase
     def test_database_rollback_raise_without_version
-      assert_raises { invoke("db:rollback_to") }
+      assert_raises { invoke("db:mongoid:rollback_to") }
     end
 
     def test_database_rollback_to
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      invoke("db:migrate")
+      invoke("db:mongoid:migrate")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -19,8 +19,8 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      with_env("VERSION" => "20100513054656") { invoke("db:rollback_to") }
+      ) { invoke("db:mongoid:migrate:status") }
+      with_env("VERSION" => "20100513054656") { invoke("db:mongoid:rollback_to") }
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -31,13 +31,13 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("db:mongoid:migrate:status") }
     end
   end
 
   def test_multidatabase_rollback_to
     Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-    invoke("db:migrate")
+    invoke("db:mongoid:migrate")
     output = <<-EOF
 
 database: mongoid_test
@@ -47,9 +47,9 @@ Status   Migration ID    Migration Name
  up     20210210125000  DefaultDatabaseMigration
  up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-    assert_output(output) { invoke("db:migrate:status") }
+    assert_output(output) { invoke("db:mongoid:migrate:status") }
     with_env("MONGOID_CLIENT_NAME" => "shard1") do
-      invoke("db:migrate")
+      invoke("db:mongoid:migrate")
       assert_output(<<-EOF
 
 database: mongoid_test_s1
@@ -59,9 +59,9 @@ Status   Migration ID    Migration Name
  up     20210210124656  ShardDatabaseMigration
  up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("db:mongoid:migrate:status") }
     end
-    with_env("VERSION" => "20210210125000") { invoke("db:rollback_to") }
+    with_env("VERSION" => "20210210125000") { invoke("db:mongoid:rollback_to") }
     output = <<-EOF
 
 database: mongoid_test
@@ -71,7 +71,7 @@ Status   Migration ID    Migration Name
  up     20210210125000  DefaultDatabaseMigration
 down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-    assert_output(output) { invoke("db:migrate:status") }
+    assert_output(output) { invoke("db:mongoid:migrate:status") }
     with_env("MONGOID_CLIENT_NAME" => "shard1") do
       assert_output(<<-EOF
 
@@ -82,12 +82,12 @@ Status   Migration ID    Migration Name
  up     20210210124656  ShardDatabaseMigration
  up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("db:mongoid:migrate:status") }
     end
 
     def test_multidatabase_rollback_to_client_target
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      invoke("db:migrate")
+      invoke("db:mongoid:migrate")
       output = <<-EOF
 
 database: mongoid_test
@@ -97,9 +97,9 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:migrate")
+        invoke("db:mongoid:migrate")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -109,8 +109,8 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
-        with_env("VERSION" => "20210210124656") { invoke("db:rollback_to") }
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
+        with_env("VERSION" => "20210210124656") { invoke("db:mongoid:rollback_to") }
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -120,7 +120,7 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -131,7 +131,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
     end
   end
 end

--- a/test/tasks/status_task_test.rb
+++ b/test/tasks/status_task_test.rb
@@ -14,8 +14,8 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
-      invoke("db:migrate")
+      ) { invoke("db:mongoid:migrate:status") }
+      invoke("db:mongoid:migrate")
       assert_output(<<-EOF
 
 database: mongoid_test
@@ -26,7 +26,7 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
    up     20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("db:mongoid:migrate:status") }
     end
 
     def test_multidatabase_migrate_status
@@ -40,8 +40,8 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
-      invoke("db:migrate")
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
+      invoke("db:mongoid:migrate")
       output = <<-EOF
 
 database: mongoid_test
@@ -51,7 +51,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
    up     20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
     end
 
     def test_multidatabase_migrate_status_in_target_client
@@ -66,8 +66,8 @@ database: mongoid_test_s1
   down    20210210124656  ShardDatabaseMigration
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
-        invoke("db:migrate")
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
+        invoke("db:mongoid:migrate")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -77,7 +77,7 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
    up     20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
       end
     end
   end

--- a/test/tasks/task_test_base.rb
+++ b/test/tasks/task_test_base.rb
@@ -5,9 +5,9 @@ load 'lib/mongoid_rails_migrations/mongoid_ext/railties/database.rake'
 module Mongoid
   class TaskTestBase < Minitest::Test #:nodoc:
     def setup
-      invoke("db:drop")
+      invoke("db:mongoid:drop")
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        invoke("db:drop")
+        invoke("db:mongoid:drop")
       end
     end
 

--- a/test/tasks/up_task_test.rb
+++ b/test/tasks/up_task_test.rb
@@ -3,7 +3,7 @@ require_relative './task_test_base'
 module Mongoid
   class UpTaskTest < TaskTestBase
     def test_database_migrate_up_raise_without_version
-      assert_raises { invoke("db:migrate:up") }
+      assert_raises { invoke("db:mongoid:migrate:up") }
     end
 
     def test_database_migrate_up
@@ -18,9 +18,9 @@ database: mongoid_test
   down    20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("db:mongoid:migrate:status") }
       with_env("VERSION" => "20100513055502") do
-        invoke("db:migrate:up")
+        invoke("db:mongoid:migrate:up")
       end
       assert_output(<<-EOF
 
@@ -32,7 +32,7 @@ database: mongoid_test
    up     20100513055502  AddSecondSurveySchema
   down    20100513063902  AddImprovementPlanSurveySchema
 EOF
-      ) { invoke("db:migrate:status") }
+      ) { invoke("db:mongoid:migrate:status") }
     end
 
 
@@ -47,7 +47,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       output = <<-EOF
 
 database: mongoid_test_s1
@@ -59,13 +59,13 @@ database: mongoid_test_s1
 EOF
 
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
       end
       with_env("VERSION" => "20210210125000") do
-        invoke("db:migrate:up")
+        invoke("db:mongoid:migrate:up")
       end
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -76,7 +76,7 @@ database: mongoid_test
    up     20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
         assert_equal(1, DataMigration.count)
         assert_equal(1, SurveySchema.count)
         Mongoid::Migrator.with_mongoid_client("shard1") do
@@ -97,7 +97,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       output = <<-EOF
 
 database: mongoid_test_s1
@@ -109,8 +109,8 @@ database: mongoid_test_s1
 EOF
 
       with_env("MONGOID_CLIENT_NAME" => "shard1", "VERSION" => "20210210124656") do
-        assert_output(output) { invoke("db:migrate:status") }
-        invoke("db:migrate:up")
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
+        invoke("db:mongoid:migrate:up")
         output = <<-EOF
 
 database: mongoid_test_s1
@@ -120,7 +120,7 @@ database: mongoid_test_s1
    up     20210210124656  ShardDatabaseMigration
   down    20210210125532  ShardDatabaseMigrationTwo
 EOF
-        assert_output(output) { invoke("db:migrate:status") }
+        assert_output(output) { invoke("db:mongoid:migrate:status") }
       end
       output = <<-EOF
 
@@ -131,7 +131,7 @@ database: mongoid_test
   down    20210210125000  DefaultDatabaseMigration
   down    20210210125800  DefaultDatabaseMigrationTwo
 EOF
-      assert_output(output) { invoke("db:migrate:status") }
+      assert_output(output) { invoke("db:mongoid:migrate:status") }
       assert_equal(0, DataMigration.count)
       Mongoid::Migrator.with_mongoid_client("shard1") do
         assert_equal(1, DataMigration.count)

--- a/test/tasks/version_task_test.rb
+++ b/test/tasks/version_task_test.rb
@@ -4,32 +4,32 @@ module Mongoid
   class VersionTaskTest < TaskTestBase
     def test_database_version
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/valid"]
-      assert_output("0\n") { invoke("db:version") }
-      invoke("db:migrate")
-      assert_output("20100513063902\n") { invoke("db:version") }
-      invoke("db:drop")
-      assert_output("0\n") { invoke("db:version") }
+      assert_output("0\n") { invoke("db:mongoid:version") }
+      invoke("db:mongoid:migrate")
+      assert_output("20100513063902\n") { invoke("db:mongoid:version") }
+      invoke("db:mongoid:drop")
+      assert_output("0\n") { invoke("db:mongoid:version") }
     end
 
     def test_multidatabase_version
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
-      assert_output("0\n") { invoke("db:version") }
-      invoke("db:migrate")
-      assert_output("20210210125800\n") { invoke("db:version") }
-      invoke("db:drop")
-      assert_output("0\n") { invoke("db:version") }
+      assert_output("0\n") { invoke("db:mongoid:version") }
+      invoke("db:mongoid:migrate")
+      assert_output("20210210125800\n") { invoke("db:mongoid:version") }
+      invoke("db:mongoid:drop")
+      assert_output("0\n") { invoke("db:mongoid:version") }
     end
 
     def test_multidatabase_version_with_target_client_and_rollback
       Mongoid::Migrator.migrations_path = [MIGRATIONS_ROOT + "/multi_shards"]
       with_env("MONGOID_CLIENT_NAME" => "shard1") do
-        assert_output("0\n") { invoke("db:version") }
-        invoke("db:migrate")
-        assert_output("20210210125532\n") { invoke("db:version") }
-        invoke("db:rollback")
-        assert_output("20210210124656\n") { invoke("db:version") }
-        invoke("db:rollback")
-        assert_output("0\n") { invoke("db:version") }
+        assert_output("0\n") { invoke("db:mongoid:version") }
+        invoke("db:mongoid:migrate")
+        assert_output("20210210125532\n") { invoke("db:mongoid:version") }
+        invoke("db:mongoid:rollback")
+        assert_output("20210210124656\n") { invoke("db:mongoid:version") }
+        invoke("db:mongoid:rollback")
+        assert_output("0\n") { invoke("db:mongoid:version") }
       end
     end
   end


### PR DESCRIPTION
Resolves #59, #24, and #53.

It builds on the previous PR but instead of allowing the user to specify a custom Rake namespace, it introduces a flag that appends the `mongoid` postfix to the `db` namespace. As a result, tasks like `db:mongoid:migrate` will be used. The behavior is configured through the `application.rb` file as follows:

```ruby
Mongoid::Migrator.with_mongoid_postfix = true
```

There is a potential limitation regarding the order in which Rake tasks are loaded. Since this PR introduces a dynamically generated namespace that depends on the `with_mongoid_postfix` flag, there is a risk that the namespace could be loaded **before** (which I'm pretty sure is loaded before `application.rb`) the user sets the flag to `true`. In this case, the user would need to reload the Rakefile after setting the postfix in order for the tasks to be properly registered (as shown in the test).

This PR is still a work in progress. I'm waiting for feedback regarding whether the load priority issue is a significant concern. Once that's clarified, I will finalize the tests and update the README. Additionally, I am unsure where to place the test for this change and would appreciate guidance on that.