### PR TITLE
Add Benchmark dependency

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,7 @@ jobs:
           - rails6-mongoid7
           - rails7-mongoid8
           - rails7-mongoid9
+          - rails8-mongoid9
         include:
           - ruby_version: '2.4'
             gemfile: rails5-mongoid6

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,8 @@ jobs:
         exclude:
           - ruby_version: 'jruby'
             gemfile: rails7-mongoid8 # JRuby 9.4.8 with Mongoid 8 has trouble finding the Logger::INFO constant
+          - ruby_version: '3.4'
+            gemfile: rails6-mongoid7 # Ruby 3.4 removed a number of standard libraries needed by Rails 6, which is EoL
 
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,12 +13,15 @@ jobs:
           - rails6-mongoid7
           - rails7-mongoid8
           - rails7-mongoid9
-          - rails8-mongoid9
         include:
           - ruby_version: '2.4'
             gemfile: rails5-mongoid6
           - ruby_version: '2.5'
             gemfile: rails5-mongoid7
+          - ruby_version: '3.2'
+            gemfile: rails8-mongoid9
+          - ruby_version: '3.3'
+            gemfile: rails8-mongoid9
           - ruby_version: '3.3'
             gemfile: rails-edge
         exclude:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby_version: ['2.7', '3.0', '3.1', '3.2', '3.3', 'jruby']
+        ruby_version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4', 'jruby']
         gemfile:
           - rails6-mongoid7
           - rails7-mongoid8
@@ -23,6 +23,8 @@ jobs:
           - ruby_version: '3.3'
             gemfile: rails8-mongoid9
           - ruby_version: '3.3'
+            gemfile: rails-edge
+          - ruby_version: '3.4'
             gemfile: rails-edge
         exclude:
           - ruby_version: 'jruby'

--- a/gemfiles/rails6-mongoid7
+++ b/gemfiles/rails6-mongoid7
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 gemspec path: ".."
+gem 'concurrent-ruby', '1.3.4'
 gem 'rails', '~> 6.1'
 gem 'mongoid', '~> 7.0'

--- a/gemfiles/rails8-mongoid9
+++ b/gemfiles/rails8-mongoid9
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gemspec path: ".."
+gem 'rails', '~> 8.1'
+gem 'mongoid', '~> 9.0'

--- a/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
+++ b/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require 'benchmark'
 
 module Mongoid #:nodoc
   # Exception that can be raised to stop migrations from going backwards.
@@ -65,15 +66,15 @@ module Mongoid #:nodoc
 
     class << self
       def up_with_benchmarks #:nodoc:
-        migrate(:up)
+        migrate(:up, benchmark: true)
       end
 
       def down_with_benchmarks #:nodoc:
-        migrate(:down)
+        migrate(:down, benchmark: true)
       end
 
       # Execute this migration in the named direction
-      def migrate(direction)
+      def migrate(direction, benchmark: false)
         return unless respond_to?(direction)
 
         case direction

--- a/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
+++ b/lib/mongoid_rails_migrations/active_record_ext/migrations.rb
@@ -66,15 +66,15 @@ module Mongoid #:nodoc
 
     class << self
       def up_with_benchmarks #:nodoc:
-        migrate(:up, benchmark: true)
+        migrate(:up)
       end
 
       def down_with_benchmarks #:nodoc:
-        migrate(:down, benchmark: true)
+        migrate(:down)
       end
 
       # Execute this migration in the named direction
-      def migrate(direction, benchmark: false)
+      def migrate(direction)
         return unless respond_to?(direction)
 
         case direction

--- a/mongoid_rails_migrations.gemspec
+++ b/mongoid_rails_migrations.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency('rails',  rails_version)
   spec.add_runtime_dependency('railties',  rails_version)
   spec.add_runtime_dependency('activesupport',  rails_version)
+  spec.add_runtime_dependency('benchmark')
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'minitest'
 end

--- a/test/migration_test.rb
+++ b/test/migration_test.rb
@@ -243,7 +243,7 @@ database: mongoid_test
       assert_raises (StandardError) do
         Mongoid::Migrator.up(MIGRATIONS_ROOT + "/crash")
       end
-      assert_match(/\A==  BasicCrash: migrating =====================================================\nAn error has occurred, 20210105165947 and all later migrations canceled:\n\nCrash migration\n.*\/test\/migrations\/crash\/20210105165947_basic_crash.rb:3:in `up'\n/, buffer)
+      assert_match(/\A==  BasicCrash: migrating =====================================================\nAn error has occurred, 20210105165947 and all later migrations canceled:\n\nCrash migration\n.*\/test\/migrations\/crash\/20210105165947_basic_crash.rb:3:in .*up'\n/, buffer)
     end
   end
 end


### PR DESCRIPTION
Rails 8.1 (specifically ActiveSupport 8.1) removed the dependency on the `benchmark` gem, causing migrations to break. This adds back that dependency. 

**Other updates**

- I also pinned `concurrent_ruby` to `1.3.4` in the Rails 6 gemfile, as version `1.3.5+` removes the Logger dependency. Rails 7.1+ fixes this, so those gemfiles have stayed the same.
- slight adjustment to the BasicCrash test, as jruby was failing. Turns out Ruby 3.4+ changed how the class was returned, causing the latest jruby (based on Ruby 3.4) to fail.